### PR TITLE
KotlinAdapter refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,9 @@ with your code or anybody elses. As in the example, package paths use forward sl
 After you're done with Gradle, simply copy the `KotlinAdapter` source file (`src/main/kotlin/io/drakon/forgelin/KotlinAdapter.kt`)
 somewhere in your project, changing the package path, then use the new path in the `Mod` annotation.
 
+Your @Mod implementation *must* be an `object`. There is no reason to make it a class and the adapter will not work if you do so.
+
 ___If this seems too complicated, just use the mod dependency. It's really easier.___
-
-## Classes or Objects?
-
-___tl;dr - Use `object`, not `class`. It's better in every way for `@Mod`.___
-
-This question is difficult to answer - for objects/classes outside your main `@Mod` object, use whatever you want. For the `@Mod` though,
-things get a little more awkward. Forgelin is designed mostly to support `object`-style mods, and all the usual FML stuff works
-with them. `class`-style works, but with one major caveat - `@SidedProxy` does **not** work right now due to the lack of statics in
-Kotlin itself. Other stuff also might be broken, bug reports welcome!
 
 ## Licenses
 Forgelin is licensed under the MIT License (see `LICENSE`).

--- a/src/main/kotlin/io/drakon/forgelin/Forgelin.kt
+++ b/src/main/kotlin/io/drakon/forgelin/Forgelin.kt
@@ -8,4 +8,4 @@ import net.minecraftforge.fml.common.Mod as mod
  * @author Arkan <arkan@drakon.io>
  */
 @mod(modid = "Forgelin", name = "Kotlin for Forge", version = "@VERSION@-@KOTLIN@", modLanguage = "kotlin", modLanguageAdapter = "io.drakon.forgelin.KotlinAdapter", acceptableRemoteVersions = "*")
-public object Forgelin {}
+object Forgelin {}

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -9,6 +9,7 @@
     "updateUrl": "",
     "authors": [
       "Arkan Emberwalker"
+      "carrot"
     ],
     "credits": "",
     "logoFile": "",


### PR DESCRIPTION
- Add the requirement that Kotlin @Mod implementations must be `object`s,
- Significantly refactor KotlinAdapter based on that assumption,
- Fix INSTANCE singleton reflection for Kotlin RC (appended $ was removed after deprecation),
- Added name to mcmod.info and Adapter authors.

I left other documentation to you for the rest of your cleanup, and only edited things that would be actively wrong.

Also removed the adapter metadata because I couldn't figure out why it was there.

I wrote this adapter for Thump in this commit, and everything works fine with Kotlin RC-1: https://github.com/CarrotCodes/Thump/commit/4ae1d063265a64cc2b3c2eeabf4114a84b1c18e2

Also note that you might not need to shade the Kotlin Reflect library any more - I don't need to for Thump, and removing it halves my built Jar size, but that seems beyond the scope of this change.
